### PR TITLE
Bind method to instance

### DIFF
--- a/RNPublisherBanner.js
+++ b/RNPublisherBanner.js
@@ -16,6 +16,7 @@ class PublisherBanner extends Component {
     this.handleSizeChange = this.handleSizeChange.bind(this);
     this.handleAppEvent = this.handleAppEvent.bind(this);
     this.handleAdFailedToLoad = this.handleAdFailedToLoad.bind(this);
+    this.loadBanner = this.loadBanner.bind(this);
     this.state = {
       style: {},
     };


### PR DESCRIPTION
To refresh an ad, we have to call `loadBanner`. It's not currently bound to the instance, so there's no way of accessing this method.